### PR TITLE
Use Note.type and generate more examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,4 @@ HOST_PORT=80
 
 # User-specified settings made visible to RStudio (APP_*)
 APP_NLPSANDBOX_SCHEMAS_VERSION=1.2.0
-APP_DATASET_VERSION=1.2.0
+APP_DATASET_VERSION=1.2.1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ instance of the [NLP Sandbox Data Node] using the [NLP Sandbox CLI].
 - NLP Sandbox schemas version: 1.2.0
 - NLP Sandbox dataset
   - Name: `i2b2-phi-dataset`
-  - Version: 1.2.0
+  - Version: 1.2.1
 
 ## Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   rstudio:
-    image: docker.synapse.org/syn22277123/i2b2-phi-dataset:1.2.0
+    image: docker.synapse.org/syn22277123/i2b2-phi-dataset:1.2.1
     build:
       context: .
       dockerfile: Dockerfile

--- a/notebooks/generate-dataset.Rmd
+++ b/notebooks/generate-dataset.Rmd
@@ -467,7 +467,7 @@ noop <- lapply(names(datasets), function(dataset_name) {
       note_text <- xml_text(xml_find_all(note_xml_doc, "//TEXT"), trim = FALSE)
       note <- list(
         text=note_text,
-        noteType="",
+        type="",
         patientId="PATIENT_ID"
       )
 
@@ -548,7 +548,7 @@ dir.create(job_output_dir, recursive = TRUE, showWarnings = FALSE)
 
 dataset_name <- "evaluation"
 dataset <- datasets[[dataset_name]]
-patient_ids <- c("110")
+patient_ids <- as.character(100:109)
 
 # patient_ids <- patient_ids[1:2]
 patient_bundles <- lapply(patient_ids, function(patient_id) {
@@ -567,7 +567,7 @@ patient_bundles <- lapply(patient_ids, function(patient_id) {
     note_text <- xml_text(xml_find_all(note_xml_doc, "//TEXT"), trim = FALSE)
     note <- list(
       text=note_text,
-      noteType="",
+      type="",
       patientId="PATIENT_ID"
     )
 


### PR DESCRIPTION
Fixes #19 

### Changelogs

- Rename `Note.noteType` to `Note.type`
- Include data from 10 patients in example dataset used for the validation of tools
- Bump dataset version to 1.2.1

### Artifacts

Dataset files on Synapse: https://www.synapse.org/#!Synapse:syn25895881